### PR TITLE
update KLIEP_optimized_alpha.R more accuracy

### DIFF
--- a/R/KLIEP_optimize_alpha.R
+++ b/R/KLIEP_optimize_alpha.R
@@ -9,7 +9,8 @@ KLIEP_optimize_alpha <- function(phi_x, phi_y, mean_phi_y) {
   } else {
     b <- matrix(colMeans(phi_y))
   }
-  c <- b / crossprod(b)[1,1]
+  nb <- norm(b)
+  c <- b / nb / nb
 
   kernel_num <- ncol(phi_x)
   max_iteration <- 100


### PR DESCRIPTION
KLIEP_optimized_alpha()の
c <- b / crossprod(b)[1, 1]
部分で， |b| << 1 の時，crossprod(b)[1, 1] が 0 になってしまい，c の成分が Inf または NaN になり最終的に score_new もNaNでエラーとなることがありました．

c <- b / crossprod(b)[1, 1]　
を
nb <- norm(b)
c <- b / nb / nb 
とすることで回避しました．




