### PR TITLE
Fix KLIEP prediction for new input data

### DIFF
--- a/R/KLIEP.R
+++ b/R/KLIEP.R
@@ -45,9 +45,9 @@ KLIEP <- function(x1, x2, sigma = "auto", kernel_num = 100, fold = 5, verbose = 
                  ),
                  fold = fold,
                  compute_density_ratio = function(x) {
-                   if(is.vector(x)) x <- matrix(x)
-                   phi_x1 <- compute_kernel_Gaussian(x1, centers, sigma)
-                   density_ratio <- as.vector(phi_x1 %*% kernel_weights)
+                   if (is.vector(x)) x <- matrix(x)
+                   phi_x <- compute_kernel_Gaussian(x, centers, sigma)
+                   density_ratio <- as.vector(phi_x %*% kernel_weights)
                    density_ratio
                  }
   )

--- a/tests/testthat/test-KLIEP.R
+++ b/tests/testthat/test-KLIEP.R
@@ -18,3 +18,16 @@ test_that("KLIEP", {
   expect_equal(head(kernel_weights), expected_kernel_weights)
   expect_equal(sigma, 0.09)
 })
+
+test_that("KLIEP compute_density_ratio uses new input", {
+  set.seed(3)
+  x1 <- rnorm(200, mean = 1, sd = 1 / 8)
+  x2 <- rnorm(200, mean = 1, sd = 1 / 2)
+
+  fit <- KLIEP(x1, x2, sigma = 0.1, verbose = FALSE)
+
+  new_x <- seq(0, 2, length.out = 11)
+  pred <- fit$compute_density_ratio(new_x)
+
+  expect_length(pred, length(new_x))
+})


### PR DESCRIPTION
## Summary

This PR fixes `KLIEP()` so that `compute_density_ratio()` evaluates the density ratio for the input data passed to the function.

Previously, `compute_density_ratio()` reused the training data when computing Gaussian kernel values, so the returned density ratio could have a length corresponding to the training data rather than the new input data.

## Changes

- Use the input passed to `compute_density_ratio()` when computing Gaussian kernel values
- Add a regression test to check that predictions are returned for the new input data

## Related issues

Fixes #13.
Partially addresses #10.