### PR TITLE
Improve uLSIF tests

### DIFF
--- a/tests/testthat/test-uLSIF.R
+++ b/tests/testthat/test-uLSIF.R
@@ -1,21 +1,34 @@
 context("uLSIF")
 
 test_that("uLSIF", {
-  set.seed(3)
+  set.seed(314)
   x <- rnorm(200, mean = 1, sd = 1/8)
   y <- rnorm(200, mean = 1, sd = 1/2)
 
-  result <- uLSIF(x, y)
+  result <- uLSIF(x, y, sigma = 0.1, lambda = 1, kernel_num = 20, verbose = FALSE)
 
-  kernel_weights <- result$kernel_weights
-  sigma <- result$kernel_info$sigma
-  lambda <- result$lambda
+  expect_s3_class(result, "uLSIF")
+  expect_equal(result$kernel_info$kernel, "Gaussian")
+  expect_equal(result$kernel_info$kernel_num, 20)
+  expect_equal(result$kernel_info$sigma, 0.1)
+  expect_equal(result$lambda, 1)
 
-  expected_kernel_weights <- c(0.0674550859, 0.0400446153, 0.0004589047,
-                               0.0168489465, 0.0670843163, 0.0189929309)
+  expect_length(result$kernel_weights, 20)
+  expect_true(all(is.finite(result$kernel_weights)))
+  expect_true(all(result$kernel_weights >= 0))
+})
 
-  testthat::skip_on_cran()
-  expect_equal(head(kernel_weights), expected_kernel_weights)
-  expect_equal(sigma, 0.1)
-  expect_equal(lambda, 1)
+test_that("uLSIF computes density ratios for new input data", {
+  set.seed(314)
+  x <- rnorm(200, mean = 1, sd = 1 / 8)
+  y <- rnorm(200, mean = 1, sd = 1 / 2)
+
+  result <- uLSIF(x, y, sigma = 0.1, lambda = 1, kernel_num = 20, verbose = FALSE)
+
+  new_x <- seq(0, 2, length.out = 11)
+  density_ratio <- result$compute_density_ratio(new_x)
+
+  expect_length(density_ratio, length(new_x))
+  expect_true(all(is.finite(density_ratio)))
+  expect_true(all(density_ratio >= 0))
 })


### PR DESCRIPTION
## Summary

This PR updates the `uLSIF()` tests to check behavioral properties rather than exact fitted numeric values.

## Changes

- Check that `uLSIF()` returns a valid fitted object
- Check that kernel weights are finite and non-negative
- Check that `compute_density_ratio()` returns one finite, non-negative value per new input
- Use explicit `sigma`, `lambda`, and `kernel_num` values to avoid depending on cross-validation results