### PR TITLE
Improve KLIEP tests

### DIFF
--- a/tests/testthat/test-KLIEP.R
+++ b/tests/testthat/test-KLIEP.R
@@ -1,33 +1,35 @@
 context("KLIEP")
 
 test_that("KLIEP", {
-  set.seed(3)
+  set.seed(314)
   x <- rnorm(200, mean = 1, sd = 1/8)
   y <- rnorm(200, mean = 1, sd = 1/2)
 
-  result <- KLIEP(x, y)
+  result <- KLIEP(x, y, sigma = 0.1, kernel_num = 20, fold = 5, verbose = FALSE)
 
-  kernel_weights <- result$kernel_weights
-  sigma <- result$kernel_info$sigma
-  lambda <- result$lambda
+  expect_true(inherits(result, "KLIEP"))
+  expect_equal(result$kernel_info$kernel, "Gaussian")
+  expect_equal(result$kernel_info$kernel_num, 20)
+  expect_equal(result$kernel_info$sigma, 0.1)
+  expect_equal(result$fold, 5)
 
-  expected_kernel_weights <- c(0.0885607375, 0.0178664639, 0.0240389107,
-                               0.0000000000, 0.0810753470, 0.0001353598)
-
-  testthat::skip_on_cran()
-  expect_equal(head(kernel_weights), expected_kernel_weights)
-  expect_equal(sigma, 0.09)
+  expect_equal(length(result$kernel_weights), 20)
+  expect_true(all(is.finite(result$kernel_weights)))
+  expect_true(all(result$kernel_weights >= 0))
+  expect_true(is.function(result$compute_density_ratio))
 })
 
 test_that("KLIEP compute_density_ratio uses new input", {
-  set.seed(3)
-  x1 <- rnorm(200, mean = 1, sd = 1 / 8)
-  x2 <- rnorm(200, mean = 1, sd = 1 / 2)
+  set.seed(314)
+  x <- rnorm(200, mean = 1, sd = 1 / 8)
+  y <- rnorm(200, mean = 1, sd = 1 / 2)
 
-  fit <- KLIEP(x1, x2, sigma = 0.1, verbose = FALSE)
+  result <- KLIEP(x, y, sigma = 0.1, kernel_num = 20, fold = 5, verbose = FALSE)
 
   new_x <- seq(0, 2, length.out = 11)
-  pred <- fit$compute_density_ratio(new_x)
+  density_ratio <- result$compute_density_ratio(new_x)
 
-  expect_length(pred, length(new_x))
+  expect_length(density_ratio, 11)
+  expect_true(all(is.finite(density_ratio)))
+  expect_true(all(density_ratio >= 0))
 })


### PR DESCRIPTION
## Summary

This PR updates the `KLIEP()` tests to check behavioral properties rather than exact fitted numeric values.

## Changes

- Check that `KLIEP()` returns a valid fitted object
- Check that kernel weights are finite and non-negative
- Check that `compute_density_ratio()` returns one finite, non-negative value per new input
- Use explicit `sigma`, `kernel_num`, and `fold` values to avoid depending on cross-validation results