### PR TITLE
Improve Gaussian kernel tests

### DIFF
--- a/tests/testthat/test-compute_kernel_Gaussian.R
+++ b/tests/testthat/test-compute_kernel_Gaussian.R
@@ -1,10 +1,18 @@
-context("compute_kernel_Gaussian")
+test_that("squared_euclid_distance computes squared Euclidean distance", {
+  expect_equal(squared_euclid_distance(c(1, 2, 3), c(4, 6, 3)), 25)
+})
 
-test_that("squared_euclid_distance", {
-  set.seed(3)
-  x <- rnorm(30)
-  y <- rnorm(1)
-  act <- squared_euclid_distance(x, y)
+test_that("kernel_Gaussian is 1 for identical inputs", {
+  expect_equal(kernel_Gaussian(c(1, 2), c(1, 2), sigma = 1), 1)
+})
 
-  expect_equal(act, 57.61699, tolerance = 1e-6)
+test_that("compute_kernel_Gaussian returns a kernel matrix", {
+  x <- matrix(c(0, 0, 1, 0, 0, 1), ncol = 2, byrow = TRUE)
+  centers <- matrix(c(0, 0, 1, 1), ncol = 2, byrow = TRUE)
+
+  result <- compute_kernel_Gaussian(x, centers, sigma = 1)
+
+  expect_equal(dim(result), c(3, 2))
+  expect_true(all(result > 0))
+  expect_true(all(result <= 1))
 })


### PR DESCRIPTION
## Summary

This PR improves tests for the Gaussian kernel helper functions.

## Changes

- Replace the random fixed-value test with deterministic examples
- Check squared Euclidean distance using a hand-computable example
- Check basic Gaussian kernel properties
- Check that `compute_kernel_Gaussian()` returns a matrix with the expected dimensions